### PR TITLE
결과화면 구현 및 해시 라우팅 처리 

### DIFF
--- a/src/component/Game.ts
+++ b/src/component/Game.ts
@@ -10,22 +10,50 @@ class Game {
   time: number;
   timerId: ReturnType<typeof setInterval> | null = null;
   word: string | null = null;
+  container: HTMLElement;
 
-  constructor(words: Word[]) {
-    this.words = words.reverse();
+  constructor(words: Word[], container: HTMLElement) {
+    this.words = [{ second: 10, text: "a" }];
     this.totalScore = words.length;
-    this.time = words[words.length - 1].second;
+    this.time = words[0].second;
+    this.container = container;
+    // this.words = words.reverse();
 
-    const scoreElement = document.getElementById("score");
-    const timeElement = document.getElementById("time");
-    const startButton = document.getElementById("start");
+    this.connectedCallback();
+  }
 
-    if (!scoreElement || !timeElement || !startButton) return;
+  connectedCallback = (): void => {
+    const template = this.getTemplate(this.time, this.totalScore);
 
-    document.querySelector(".top")?.classList.add("visible");
+    this.container.innerHTML = template;
+    this.attachEvent();
+  };
 
-    scoreElement.innerText = `점수: ${this.totalScore}점`;
-    timeElement.innerText = `남은 시간: ${this.time}초`;
+  getTemplate = (time = 0, score = 0): string => {
+    return `
+      <div id="container">
+        <div class="top">
+          <span id="time">남은 시간: ${time}초</span>
+          <span id="score">점수: ${score}점</span>
+        </div>
+        <div id="word">문제 단어</div>
+        <div class="word-input">
+          <input id="answer" type="text" />
+        </div>
+        <div class="bottom">
+          <button class="game-btn" data-action="start">시작</button>
+        </div>
+      </div>
+      `;
+  };
+
+  attachEvent = (): void => {
+    const startButton = document.querySelector(".game-btn") as HTMLElement;
+
+    if (!startButton) {
+      console.warn("start button not found");
+      return;
+    }
 
     startButton.addEventListener("click", (): void => {
       const action = startButton.dataset.action;
@@ -33,7 +61,7 @@ class Game {
       switch (action) {
         case "start":
           startButton.innerText = `초기화`;
-          startButton.dataset.action = "resume";
+          startButton.dataset.action = `resume`;
           this.startGame();
           break;
         case "resume":
@@ -44,15 +72,14 @@ class Game {
           break;
       }
     });
-  }
+  };
 
   startGame = (): void => {
     const scoreElement = document.getElementById("score");
     const timeElement = document.getElementById("time");
-    const startButton = document.getElementById("start");
     const inputElement = document.getElementById("answer") as HTMLInputElement;
 
-    if (!scoreElement || !timeElement || !startButton || !inputElement) return;
+    if (!scoreElement || !timeElement || !inputElement) return;
 
     inputElement.focus();
 
@@ -80,18 +107,10 @@ class Game {
   showWord = (word: Word): void => {
     const scoreElement = document.getElementById("score");
     const timeElement = document.getElementById("time");
-    const startButton = document.getElementById("start");
     const inputElement = document.getElementById("answer");
     const wordElement = document.getElementById("word");
 
-    if (
-      !scoreElement ||
-      !timeElement ||
-      !startButton ||
-      !inputElement ||
-      !wordElement
-    )
-      return;
+    if (!scoreElement || !timeElement || !inputElement || !wordElement) return;
 
     this.word = word.text;
     this.time = word.second;
@@ -111,9 +130,8 @@ class Game {
   clearWord = (): void => {
     const scoreElement = document.getElementById("score");
     const timeElement = document.getElementById("time");
-    const startButton = document.getElementById("start");
 
-    if (!scoreElement || !timeElement || !startButton) return;
+    if (!scoreElement || !timeElement) return;
 
     this.timerId && clearInterval(this.timerId);
     this.timerId = null;
@@ -128,6 +146,8 @@ class Game {
 
     if (!word) {
       console.log("go to result page");
+
+      window.location.hash = "result";
       return;
     }
 

--- a/src/component/Result.ts
+++ b/src/component/Result.ts
@@ -1,8 +1,11 @@
-const Result = (
-  container: HTMLElement,
-  score: number,
-  average: number
-): void => {
+export interface ResultData {
+  score: number;
+  average: number;
+}
+
+const renderResult = (container: HTMLElement, data: ResultData): void => {
+  const { score = 0, average = 0 } = data;
+
   const template = `
     <div class="result">
       <p class="greeting">Mission Complete!</p>
@@ -25,4 +28,4 @@ const Result = (
   });
 };
 
-export default Result;
+export default renderResult;

--- a/src/component/Result.ts
+++ b/src/component/Result.ts
@@ -1,0 +1,28 @@
+const Result = (
+  container: HTMLElement,
+  score: number,
+  average: number
+): void => {
+  const template = `
+    <div class="result">
+      <p class="greeting">Mission Complete!</p>
+      <p class="score">당신의 점수는 ${score}점입니다</p>
+      <p class="average">단어당 평균 답변 시간은 ${average}초입니다.</p>
+      <button id='restart-btn' class="game-btn">다시 시작</button>
+    </div>
+    `;
+
+  container.innerHTML = template;
+
+  const restartButton = document.getElementById("restart-btn");
+
+  if (!restartButton) {
+    throw new Error("No restart button");
+  }
+
+  restartButton.addEventListener("click", () => {
+    window.location.hash = "";
+  });
+};
+
+export default Result;

--- a/src/index.css
+++ b/src/index.css
@@ -11,16 +11,33 @@
   display: flex;
   justify-content: space-between;
   margin-bottom: 15px;
-  visibility: hidden;
-}
-
-.visible {
-  visibility: visible;
 }
 
 .top span {
   padding: 5px 20px 5px 20px;
   line-height: 1.5rem;
+}
+
+.result {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  align-items: center;
+  border: 1px solid black;
+}
+
+.result .greeting {
+  font-size: 1.2rem;
+  font-weight: bold;
+}
+
+.result .score {
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.result .average {
+  font-size: 1.1rem;
 }
 
 input {
@@ -37,7 +54,7 @@ input {
   margin-top: 10px;
 }
 
-.bottom button {
+.game-btn {
   padding: 5px 10px 5px 10px;
   font-size: 1.2rem;
 }

--- a/src/index.html
+++ b/src/index.html
@@ -6,18 +6,6 @@
     <title>Typing Game</title>
   </head>
   <body>
-    <div id="container">
-      <div class="top">
-        <span id="time">남은 시간: 0초</span>
-        <span id="score">점수: 0점</span>
-      </div>
-      <div id="word">문제 단어</div>
-      <div class="word-input">
-        <input id="answer" type="text" />
-      </div>
-      <div class="bottom">
-        <button id="start" data-action="start">시작</button>
-      </div>
-    </div>
+    <div id="target"></div>
   </body>
 </html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,39 @@
 import Game, { Word } from "./component/Game";
+import Result from "./component/Result";
 import "./index.css";
 
 document.addEventListener("DOMContentLoaded", () => {
-  const container = document.getElementById("container");
+  const container = document.getElementById("target");
 
   if (!container) {
     return;
   }
 
+  window.addEventListener("hashchange", (): void => {
+    if (window.location.hash === "#") {
+      fetch("https://my-json-server.typicode.com/kakaopay-fe/resources/words")
+        .then((res: Response): Promise<Word[]> => res.json())
+        .then((res: Word[]): void => {
+          // @TODO: 라우터 구현하면서 개선해야함
+          new Game(res, container);
+        })
+        .catch((e): void => {
+          console.error(e);
+        });
+    }
+
+    if (window.location.hash === "#result") {
+      console.log("결과화면");
+      // @TODO
+      Result(container, 10, 4);
+    }
+  });
+
   fetch("https://my-json-server.typicode.com/kakaopay-fe/resources/words")
     .then((res: Response): Promise<Word[]> => res.json())
     .then((res: Word[]): void => {
       // @TODO: 라우터 구현하면서 개선해야함
-      new Game(res);
+      new Game(res, container);
     })
     .catch((e): void => {
       console.error(e);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import Game, { Word } from "./component/Game";
+import renderGame, { Word } from "./component/Game";
 import renderResult from "./component/Result";
 import "./index.css";
 
@@ -10,28 +10,14 @@ document.addEventListener("DOMContentLoaded", () => {
     return;
   }
 
-  const game = new Game(container);
-
   window.location.hash = "";
 
-  getWordsAPI()
-    .then((res: Word[]): void => {
-      game.init(res);
-    })
-    .catch((e): void => {
-      throw new Error(`API FAILED: ${e}`);
-    });
+  initGame(container);
 
   window.addEventListener("hashchange", (): void => {
     const hash = window.location.hash;
     if (hash === "") {
-      getWordsAPI()
-        .then((res: Word[]): void => {
-          game.init(res);
-        })
-        .catch((e): void => {
-          throw new Error(`API FAILED: ${e}`);
-        });
+      initGame(container);
     }
 
     if (hash.startsWith("#result")) {
@@ -41,6 +27,16 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 });
+
+function initGame(container: HTMLElement): void {
+  getWordsAPI()
+    .then((res: Word[]): void => {
+      renderGame(container, res);
+    })
+    .catch((e): void => {
+      console.error(`API FAILED: ${e}`);
+    });
+}
 
 function getWordsAPI(): Promise<Word[]> {
   return fetch(


### PR DESCRIPTION
## 목표

✨  해시값에 따라 올바른 컴포넌트가 렌더링되도록 한다
✨  게임의 결과를 화면에 표시한다

## 작업내역

- hash값에 따라 라우팅하도록 함
  - history API를 쓰는 방법도 있지만, 웹서버 없이 하나의 html을 서브하는 정적인 페이지를 만들고 있으므로 적절치 않다. 트레이드오프로 앞으로가기/뒤로가기 등을 쓰지 못한다
- Game 컴포넌트 변수 및 메소드의 네이밍과 구조 재정리
  - web component스럽게 인터페이스를 짰으나, 커스텀 엘리먼트 자체를 구현한 것이 아니기 때문에 메소드의 목적을 벗어나는 코드들이 추가됨. 하위 메소드로 분리를 할까 싶었지만 한눈에 코드를 읽기 어려워 우선 재정리함 
- 결과화면 구현 
  - hash값 뒤에 세팅된 파라미터를 보고 결과 렌더링  