### PR TITLE
IE 크로스브라우징 이슈 수정 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7799,6 +7799,11 @@
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
       "dev": true
     },
+    "whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
+    },
     "which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "webpack-dev-server": "^3.11.2"
   },
   "dependencies": {
-    "core-js": "^3.9.1"
+    "core-js": "^3.9.1",
+    "whatwg-fetch": "^3.6.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ document.addEventListener("DOMContentLoaded", () => {
   window.location.hash = "";
   window.addEventListener("hashchange", (): void => {
     const hash = window.location.hash;
-    if (hash === "") {
+    if (hash === "" || hash === "#") {
       renderGame(container, words);
       /* 새 API 요청이 필요한 경우
       getWords().then((words: Word[]) => renderGame(container, words));

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = {
   mode: "development",
   devtool: "inline-source-map",
   entry: {
-    index: "./src/index.ts",
+    index: ["whatwg-fetch", "./src/index.ts"],
   },
   output: {
     path: path.resolve(__dirname, "public"),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,8 +17,9 @@ module.exports = {
   resolve: {
     extensions: [".ts", ".js"],
   },
+  target: ["web", "es5"],
   devServer: {
-    contentBase: "./dist", // Content base
+    contentBase: "./public", // Content base
     inline: true, // Enable watch and live reload
     host: "localhost",
     port: 8080,
@@ -27,7 +28,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.ts$/,
+        test: /\.(ts|js)$/,
         loader: "babel-loader",
         exclude: [/node_modules/],
       },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,6 @@ module.exports = {
   },
   target: ["web", "es5"],
   devServer: {
-    contentBase: "./public", // Content base
     inline: true, // Enable watch and live reload
     host: "localhost",
     port: 8080,


### PR DESCRIPTION
## 목표

🐛 IE에서도 웹앱이 올바르게 작동해야 한다 

## 작업내역
> 관련이슈 #13 

- fetch 폴리필 적용
- 웹팩 부트스트래핑의 화살표 함수 제거
- 빈 해쉬값을 IE에서도 인식하게 함 